### PR TITLE
[WIP] Tentative update of the maven file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,18 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>[4.6.0,)</version>
+            <version>4.1</version>
         </dependency>
-
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.10.14</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity</artifactId>
+            <version>1.7</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -103,8 +112,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,29 +1,26 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    
     <parent>
-        <groupId>org.agmip.parent</groupId>
-        <artifactId>agmip-translator-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <groupId>org.agmip.translators</groupId>
+        <artifactId>translator-dist</artifactId>
+        <version>1.0.3</version>
     </parent>
+
     <groupId>org.agmip.translators</groupId>
     <artifactId>translator-sarrah</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
-    <name>AgMIP SarraH Translator</name>
+    <name>translator-sarrah</name>
     <description>
-        AgMIP Sarrah Translator
+        AgMIP SarraH Translator
     </description>
     <url>http://www.agmip.org/</url>
-
-    <issueManagement>
-        <url>https://github.com/agmip/translator-sarrah/issues</url>
-        <system>GitHub Issues</system>
-    </issueManagement>
 
     <licenses>
         <license>
             <name>BSD License</name>
-            <url>https://raw.github.com/agmip/translator-sarrah/master/LICENSE</url>
+            <url>https://raw.github.com/agmip/translator-sarrah/develop/LICENSE</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -37,34 +34,143 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.agmip.ace</groupId>
-            <artifactId>ace-core</artifactId>
+            <groupId>org.agmip</groupId>
+            <artifactId>agmip-core</artifactId>
+            <version>1.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.agmip</groupId>
             <artifactId>agmip-common-functions</artifactId>
-            <version>1.3.13-SNAPSHOT</version>
+            <version>1.3.15</version>
         </dependency>
         <dependency>
             <groupId>org.agmip</groupId>
-            <artifactId>dome</artifactId>
-            <version>1.4.12-SNAPSHOT</version>
+            <artifactId>ace-lookup</artifactId>
+            <version>1.2.6</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>[4.13.1,)</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>[1.2.0,)</version>
+        </dependency>
+        <dependency>
+            <groupId>org.agmip</groupId>
+            <artifactId>acmo</artifactId>
+            <version>1.1.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.agmip.ace</groupId>
+            <artifactId>ace-core</artifactId>
+            <version>2.1.4</version>
         </dependency>
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
+            <version>[4.6.0,)</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-        </dependency>
+
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.5</version>
+                <configuration>
+                    <message>Building site for ${project.version}</message>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>site</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <pushChanges>false</pushChanges>
+                    <localCheckout>true</localCheckout>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <keyname>${gpg.keyname}</keyname>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
This is not yet working.

I clone and build successfully 
-  agmip-core
- agmip-translator
- translator-dssat

When I run `mvn compile -f pom.xml` , I have the following errors:

    Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project translator-sarrah: Compilation failure: Compilation failure: 
    [ERROR] error: Source option 5 is no longer supported. Use 6 or later.
    [ERROR] error: Target option 1.5 is no longer supported. Use 1.6 or later.

